### PR TITLE
Added #109 make duration optional for MoasicDefinition

### DIFF
--- a/src/schema/MosaicCreationTransactionSchema.js
+++ b/src/schema/MosaicCreationTransactionSchema.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { array, Schema, string, TypeSize, ubyte, uint, ushort } from './Schema';
+import { array, Schema, TypeSize, ubyte, uint, ushort } from './Schema';
 
 /**
  * @module schema/MosaicCreationTransactionSchema
@@ -24,7 +24,7 @@ import { array, Schema, string, TypeSize, ubyte, uint, ushort } from './Schema';
  * Mosaic definition creation transaction schema
  * @const {module:schema/Schema}
  */
-const schema = new Schema([
+export const schema = new Schema([
 	uint('size'),
 	array('signature'),
 	array('signer'),
@@ -41,4 +41,17 @@ const schema = new Schema([
 	array('duration', TypeSize.INT)
 ]);
 
-export default schema;
+export const schemaNoDuration = new Schema([
+	uint('size'),
+	array('signature'),
+	array('signer'),
+	ushort('version'),
+	ushort('type'),
+	array('fee', TypeSize.INT),
+	array('deadline', TypeSize.INT),
+	array('nonce', TypeSize.BYTE),
+	array('mosaicId', TypeSize.INT),
+	ubyte('numOptionalProperties'),
+	ubyte('flags'),
+	ubyte('divisibility')
+]);

--- a/test/transactions/MosaicCreationTransaction.spec.js
+++ b/test/transactions/MosaicCreationTransaction.spec.js
@@ -51,4 +51,34 @@ describe('MosaicCreationTransaction', () => {
 		expect(transactionPayload.payload.substring(240, transactionPayload.payload.length))
 			.to.be.equal('E6DE84B88675F65ED72E4B43010104021027000000000000');
 	});
+
+	it('should create mosaic definition transaction without duration', () => {
+		const nonce = new Uint8Array([0xE6, 0xDE, 0x84, 0xB8]);
+		const mosaicCreationTransaction = {
+			deadline: deadline(),
+			duration: [],
+			divisibility: 4,
+			nonce,
+			mosaicId: mosaicId(nonce, convert.hexToUint8(keyPair.publicKey))
+		};
+
+		const verifiableTransaction = new MosaicCreationTransaction.Builder()
+			.addDeadline(mosaicCreationTransaction.deadline)
+			.addSupplyMutable()
+			.addDivisibility(mosaicCreationTransaction.divisibility)
+			.addDuration(mosaicCreationTransaction.duration)
+			.addNonce(mosaicCreationTransaction.nonce)
+			.addMosaicId(mosaicCreationTransaction.mosaicId)
+			.build();
+
+		const transactionPayload = verifiableTransaction.signTransaction(keyPair);
+
+		/**
+		 * If no duration provided, the new tx size changed to 135.
+		 * as indicatorDuration and Duration attribute get removed from the buffer schema
+		 */
+		expect(transactionPayload.payload.substring(0, 8)).to.be.equal('87000000');
+		expect(transactionPayload.payload.substring(240, transactionPayload.payload.length))
+			.to.be.equal('E6DE84B88675F65ED72E4B43000104');
+	});
 });


### PR DESCRIPTION
Issue [109](https://github.com/nemtech/nem2-sdk-typescript-javascript/issues/109)

- Changed MosaicDefinitionTransaction to allow undefined `Duration`
- Changed MosaicDefinitionTransaction buffer schema to handle `Duration` provided / unprovided request.
