### PR TITLE
v0.9.16: Fixed message encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## v0.9.16
+
+- Version fix
+
+## v0.9.15
+
+- Fixed message encryption to use sha3
+- Added signTransactionGivenSignatures
+
 ## v0.9.14
 
 - Fixed MosaicDefinition schema, added `schemaNoDuration` for optional duration

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ $ docker run --rm -v ${PWD}:/local swaggerapi/swagger-codegen-cli generate -i /l
 
 Important versions listed below. Refer to the [Changelog](CHANGELOG.md) for a full history of the project.
 
+- [v0.9.16](CHANGELOG.md#v0916) - **Cow Compatible** - 2019-05-06
+- [v0.9.15](CHANGELOG.md#v0915) - **Cow Compatible** - 2019-05-01
 - [v0.9.14](CHANGELOG.md#v0914) - **Cow Compatible** - 2019-04-10
 - [v0.9.13](CHANGELOG.md#v0913) - **Cow Compatible** - 2019-03-24
 - [v0.9.12](CHANGELOG.md#v0912) - **Cow Compatible** - 2019-03-10

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-library",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-library",
-  "version": "0.9.15",
+  "version": "0.9.16",
   "description": "nem2-library-js",
   "license": "APACHE-2.0",
   "main": "dist/index.js",


### PR DESCRIPTION
Publishing new version because 0.9.15 did not include latest encryption and cosignatories fixes.